### PR TITLE
Add Friendly Timestamp Attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ return msg;
 | timeout | string | none | Attribute **required** for `due` config option. `minutes`, `days`, `weeks`, `months`, `years`.
 | text | object | none | A list defining the text displayed. `minute(s)`, `day(s)`, `week(s)`, `month(s)`, `year(s)`, `ago`, `less_than`, `more_than`, `due_by`, `over_by`.
 | due | boolean | false | Sets the card to display the due time based on `timeout` value set in the config.
+| locale | string | 'en-us' | Sets the friendly timestamp locale.
 | unit_of_measurement | string | none | Define the unit of measurement of the sensor.
 | icon | string | mdi:checkbox-marked | Define a custom icon for this sensor.
 | undo_timeout | number | 15 | Time until undo button times out in seconds.

--- a/src/check-button-card.ts
+++ b/src/check-button-card.ts
@@ -88,7 +88,8 @@ class CheckButtonCard extends HTMLElement {
         over_by: 'over by'
       },
       display_limit: null,
-      due: false
+      due: false,
+      locale: 'en-us'
     };
 
     // Merge text objects
@@ -605,6 +606,7 @@ class CheckButtonCard extends HTMLElement {
     const config = this._config;
     let payload: any = {};
     payload.timestamp = timestamp;
+    payload.timestamp_friendly = new Date(timestamp*1000).toLocaleString(config.locale);
     payload.timeout = config.timeout;
     if (config.timeout) {
       payload.timeout_timestamp = this._convertToSeconds(config.timeout) + Number(timestamp);


### PR DESCRIPTION
Makes life easy if you are trying to work out when you actually pressed the button!

Included config option to change locale, in my case, I've defined it as 'en-au'

![image](https://user-images.githubusercontent.com/31495062/87121512-3e22c280-c2c6-11ea-9f8c-ea8906d67d3d.png)
